### PR TITLE
Feature/http4s 0.19.x upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ libraryDependencies += "com.github.gvolpe" %% "http4s-tracer" % Version
 | Dependency   | Version    |
 | ------------ |:----------:|
 | cats         | 1.1.1      |
-| cats-effect  | 0.10.1     |
-| fs2          | 0.10.4     |
+| cats-effect  | 1.0.0-RC2  |
+| fs2          | 1.0.0-M1   |
 | gfc-timeuuid | 0.0.8      |
-| http4s       | 0.18.12    |
+| http4s       | 0.19.0-M1  |
 
 ### Credits
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := """https-tracer-root"""
 
 organization in ThisBuild := "com.github.gvolpe"
 
-version in ThisBuild := "0.2"
+version in ThisBuild := "1.0-M1"
 
 crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6")
 

--- a/core/src/main/scala/com/github/gvolpe/tracer/TracedHttpRoute.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/TracedHttpRoute.scala
@@ -21,12 +21,12 @@ import cats.data.{Kleisli, OptionT}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import com.github.gvolpe.tracer.Tracer.TraceId
-import org.http4s.{HttpService, Request, Response}
+import org.http4s.{HttpRoutes, Request, Response}
 
 object TracedHttpRoute {
   case class TracedRequest[F[_]](traceId: TraceId, request: Request[F])
 
-  def apply[F[_]: Monad](pf: PartialFunction[TracedRequest[F], F[Response[F]]]): HttpService[F] =
+  def apply[F[_]: Monad](pf: PartialFunction[TracedRequest[F], F[Response[F]]]): HttpRoutes[F] =
     Kleisli[OptionT[F, ?], Request[F], Response[F]] { req =>
       OptionT {
         Tracer

--- a/core/src/main/scala/com/github/gvolpe/tracer/Tracer.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/Tracer.scala
@@ -22,7 +22,7 @@ import cats.effect.Sync
 import cats.syntax.all._
 import com.gilt.timeuuid.TimeUuid
 import org.http4s.syntax.StringSyntax
-import org.http4s.{Header, HttpService, Request, Response}
+import org.http4s.{Header, HttpRoutes, Request, Response}
 
 /**
   * `org.http4s.server.HttpMiddleware` that either tries to get a Trace-Id from the headers or otherwise
@@ -50,8 +50,8 @@ object Tracer extends StringSyntax {
   type KFX[F[_], A] = Kleisli[F, TraceId, A]
 
   // format: off
-  def apply[F[_]](service: HttpService[F], headerName: String = DefaultTraceIdHeader)
-                 (implicit F: Sync[F], L: TracerLog[KFX[F, ?]]): HttpService[F] =
+  def apply[F[_]](service: HttpRoutes[F], headerName: String = DefaultTraceIdHeader)
+                 (implicit F: Sync[F], L: TracerLog[KFX[F, ?]]): HttpRoutes[F] =
     Kleisli[OptionT[F, ?], Request[F], Response[F]] { req =>
       val createId: F[(Request[F], TraceId)] =
         for {

--- a/core/src/main/scala/com/github/gvolpe/tracer/instances/tracerlog.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/instances/tracerlog.scala
@@ -18,6 +18,7 @@ package com.github.gvolpe.tracer.instances
 
 import cats.data.Kleisli
 import cats.effect.Sync
+import cats.syntax.flatMap._
 import com.github.gvolpe.tracer.Tracer.KFX
 import com.github.gvolpe.tracer.TracerLog
 import org.slf4j.{Logger, LoggerFactory}
@@ -28,19 +29,19 @@ object tracerlog {
 
   implicit def defaultLog[F[_]](implicit F: Sync[F]): TracerLog[KFX[F, ?]] =
     new TracerLog[KFX[F, ?]] {
-      def logger[A](implicit ct: ClassTag[A]): Logger =
-        LoggerFactory.getLogger(ct.runtimeClass)
+      def logger[A](implicit ct: ClassTag[A]): F[Logger] =
+        F.delay(LoggerFactory.getLogger(ct.runtimeClass))
 
       override def info[A: ClassTag](value: String): KFX[F, Unit] = Kleisli { id =>
-        F.delay(logger[A].info(s"$id >> $value"))
+        logger[A].flatMap(log => F.delay(log.info(s"$id >> $value")))
       }
 
       override def error[A: ClassTag](error: Exception): KFX[F, Unit] = Kleisli { id =>
-        F.delay(logger[A].error(s"$id >> ${error.getMessage}"))
+        logger[A].flatMap(log => F.delay(log.error(s"$id >> ${error.getMessage}")))
       }
 
       override def warn[A: ClassTag](value: String): KFX[F, Unit] = Kleisli { id =>
-        F.delay(logger[A].warn(s"$id >> $value"))
+        logger[A].flatMap(log => F.delay(log.warn(s"$id >> $value")))
       }
     }
 

--- a/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
@@ -24,7 +24,7 @@ import com.github.gvolpe.tracer.interpreter.UserTracerInterpreter
 import com.github.gvolpe.tracer.instances.tracerlog._
 import com.github.gvolpe.tracer.repository.UserTracerRepository
 import com.github.gvolpe.tracer.repository.algebra.UserRepository
-import org.http4s.HttpService
+import org.http4s.HttpRoutes
 
 class Module[F[_]: Sync] {
 
@@ -34,10 +34,10 @@ class Module[F[_]: Sync] {
   private val service: UserAlgebra[KFX[F, ?]] =
     new UserTracerInterpreter[F](repo)
 
-  private val httpRoutes: HttpService[F] =
+  private val httpRoutes: HttpRoutes[F] =
     new UserRoutes[F](service).routes
 
-  val routes: HttpService[F] =
+  val routes: HttpRoutes[F] =
     Tracer(httpRoutes, headerName = "Flow-Id") // Header name is optional, default to "Trace-Id"
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
@@ -38,7 +38,7 @@ class AuthRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]]) extends Http4s
 
   lazy val authMiddleware: AuthMiddleware[F, String] = ???
 
-  lazy val routes: HttpService[F] = Router(
+  lazy val routes: HttpRoutes[F] = Router(
     PathPrefix -> authMiddleware(httpRoutes)
   )
 

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
@@ -31,7 +31,7 @@ class UserRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]]) extends Http4s
 
   private[http] val PathPrefix = "/users"
 
-  private val httpRoutes: HttpService[F] = TracedHttpRoute[F] {
+  private val httpRoutes: HttpRoutes[F] = TracedHttpRoute[F] {
     case GET -> Root / username using traceId =>
       userService
         .find(Username(username))
@@ -53,7 +53,7 @@ class UserRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]]) extends Http4s
       }
   }
 
-  val routes: HttpService[F] = Router(
+  val routes: HttpRoutes[F] = Router(
     PathPrefix -> httpRoutes
   )
 

--- a/examples/src/test/scala/com/github/gvolpe/tracer/http/HttpRoutesSpec.scala
+++ b/examples/src/test/scala/com/github/gvolpe/tracer/http/HttpRoutesSpec.scala
@@ -19,13 +19,13 @@ package com.github.gvolpe.tracer.http
 import cats.effect.IO
 import com.github.gvolpe.tracer.IOAssertion
 import org.http4s.client.dsl.Http4sClientDsl
-import org.http4s.{HttpService, Request, Status}
+import org.http4s.{HttpRoutes, Request, Status}
 import org.scalatest.{Assertion, FunSuite}
 import org.scalatest.prop.{PropertyChecks, TableFor3}
 
 class HttpRoutesSpec extends FunSuite with PropertyChecks with Http4sClientDsl[IO] {
 
-  def propertySpec(requests: TableFor3[String, IO[Request[IO]], Status], routes: HttpService[IO]): Unit =
+  def propertySpec(requests: TableFor3[String, IO[Request[IO]], Status], routes: HttpRoutes[IO]): Unit =
     forAll(requests) { (description, request, expectedStatus) =>
       test(description) {
         IOAssertion {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val catsEffect  = "0.10.1"
-    val fs2         = "0.10.4"
-    val http4s      = "0.18.12"
+    val catsEffect  = "1.0.0-RC2"
+    val fs2         = "1.0.0-M1"
+    val http4s      = "0.19.0-M1"
     val circe       = "0.9.3"
     val gfcTimeuuid = "0.0.8"
 
@@ -14,7 +14,7 @@ object Dependencies {
     val scalaCheck  = "1.13.5"
 
     // Compiler
-    val kindProjector     = "0.9.5"
+    val kindProjector     = "0.9.7"
     val betterMonadicFor  = "0.2.4"
 
     // Runtime


### PR DESCRIPTION
Updates local version to `1.0-M1`. The idea is that the branch `1.x` should be binary compatible with latest `http4s v0.19.x`.