### PR TITLE
Implicit tracer context

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/tracer/TracedHttpRoute.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/TracedHttpRoute.scala
@@ -26,7 +26,8 @@ import org.http4s.{HttpRoutes, Request, Response}
 object TracedHttpRoute {
   case class TracedRequest[F[_]](traceId: TraceId, request: Request[F])
 
-  def apply[F[_]: Monad](pf: PartialFunction[TracedRequest[F], F[Response[F]]]): HttpRoutes[F] =
+  def apply[F[_]: Monad](pf: PartialFunction[TracedRequest[F], F[Response[F]]])(
+      implicit TC: TracerContext): HttpRoutes[F] =
     Kleisli[OptionT[F, ?], Request[F], Response[F]] { req =>
       OptionT {
         Tracer

--- a/core/src/main/scala/com/github/gvolpe/tracer/TracerContext.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/TracerContext.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 com.github.gvolpe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.tracer
+
+trait TracerContext {
+  def headerName: String
+}
+
+object TracerContext {
+  def apply(implicit ev: TracerContext): TracerContext = ev
+}
+
+object DefaultTracerContext extends TracerContext {
+  override val headerName = "Trace-Id"
+}

--- a/core/src/main/scala/com/github/gvolpe/tracer/auth/AuthTracedHttpRoute.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/auth/AuthTracedHttpRoute.scala
@@ -20,14 +20,15 @@ import cats.Monad
 import cats.data.{Kleisli, OptionT}
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import com.github.gvolpe.tracer.Tracer
+import com.github.gvolpe.tracer.{Tracer, TracerContext}
 import com.github.gvolpe.tracer.Tracer.TraceId
 import org.http4s.{AuthedRequest, AuthedService, Response}
 
 object AuthTracedHttpRoute {
   case class AuthTracedRequest[F[_], T](traceId: TraceId, request: AuthedRequest[F, T])
 
-  def apply[T, F[_]: Monad](pf: PartialFunction[AuthTracedRequest[F, T], F[Response[F]]]): AuthedService[T, F] =
+  def apply[T, F[_]: Monad](pf: PartialFunction[AuthTracedRequest[F, T], F[Response[F]]])(
+      implicit TC: TracerContext): AuthedService[T, F] =
     Kleisli[OptionT[F, ?], AuthedRequest[F, T], Response[F]] { req =>
       OptionT {
         Tracer

--- a/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
@@ -29,6 +29,8 @@ import org.http4s.implicits._
 
 class Module[F[_]: Sync] {
 
+  implicit val tracerContext = DefaultTracerContext // Default Header name is "Trace-Id"
+
   private val repo: UserRepository[KFX[F, ?]] =
     new UserTracerRepository[F]
 
@@ -39,6 +41,6 @@ class Module[F[_]: Sync] {
     new UserRoutes[F](service).routes
 
   val httpApp: HttpApp[F] =
-    Tracer(httpRoutes.orNotFound, headerName = "Flow-Id") // Header name is optional, default to "Trace-Id"
+    Tracer(httpRoutes.orNotFound)
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
@@ -18,13 +18,15 @@ package com.github.gvolpe.tracer.http
 
 import cats.effect.Sync
 import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.TracerContext
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.auth.{AuthTracedHttpRoute, Http4sAuthTracerDsl}
 import io.circe.generic.auto._
 import org.http4s._
 import org.http4s.server.{AuthMiddleware, Router}
 
-class AuthRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]]) extends Http4sAuthTracerDsl[F] {
+class AuthRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]])(implicit TC: TracerContext)
+    extends Http4sAuthTracerDsl[F] {
 
   private[http] val PathPrefix = "/auth"
 

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
@@ -22,12 +22,13 @@ import com.github.gvolpe.tracer.Tracer.KFX
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.model.user.{User, Username}
 import com.github.gvolpe.tracer.program.{UserAlreadyExists, UserNotFound}
-import com.github.gvolpe.tracer.{Http4sTracerDsl, TracedHttpRoute}
+import com.github.gvolpe.tracer.{Http4sTracerDsl, TracedHttpRoute, TracerContext}
 import io.circe.generic.auto._
 import org.http4s._
 import org.http4s.server.Router
 
-class UserRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]]) extends Http4sTracerDsl[F] {
+class UserRoutes[F[_]: Sync](userService: UserAlgebra[KFX[F, ?]])(implicit TC: TracerContext)
+    extends Http4sTracerDsl[F] {
 
   private[http] val PathPrefix = "/users"
 


### PR DESCRIPTION
Attempt to solve #9 . 

What I don't like about this solution is that it makes the usage of the API worse by forcing all the HTTP routes to have an `implicit TC: TracerContext`. I'd rather have dirty internals with a simple `var` over doing this.