### PR TITLE
Introducing KFX.apply + fixing TraceLog#error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := """https-tracer-root"""
 
 organization in ThisBuild := "com.github.gvolpe"
 
-version in ThisBuild := "1.0-M3"
+version in ThisBuild := "1.0-M4"
 
 crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6")
 

--- a/core/src/main/scala/com/github/gvolpe/tracer/KFX.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/KFX.scala
@@ -16,10 +16,11 @@
 
 package com.github.gvolpe.tracer
 
-import scala.reflect.ClassTag
+import cats.data.Kleisli
+import Tracer.TraceId
 
-trait TracerLog[F[_]] {
-  def info[A: ClassTag](value: String): F[Unit]
-  def error[A: ClassTag](value: String): F[Unit]
-  def warn[A: ClassTag](value: String): F[Unit]
+object KFX {
+  type KFX[F[_], A] = Kleisli[F, TraceId, A]
+
+  def apply[F[_], A](run: TraceId => F[A]): KFX[F, A] = Kleisli[F, TraceId, A](run)
 }

--- a/core/src/main/scala/com/github/gvolpe/tracer/Tracer.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/Tracer.scala
@@ -42,12 +42,12 @@ import org.http4s.{Header, HttpApp, Request}
   * */
 object Tracer extends StringSyntax {
 
+  import KFX._
+
   private[tracer] val DefaultTraceIdHeader = "Trace-Id"
   private var TraceIdHeader                = DefaultTraceIdHeader
 
   final case class TraceId(value: String) extends AnyVal
-
-  type KFX[F[_], A] = Kleisli[F, TraceId, A]
 
   // format: off
   def apply[F[_]](http: HttpApp[F], headerName: String = DefaultTraceIdHeader)

--- a/core/src/main/scala/com/github/gvolpe/tracer/instances/tracerlog.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/instances/tracerlog.scala
@@ -16,10 +16,10 @@
 
 package com.github.gvolpe.tracer.instances
 
-import cats.data.Kleisli
 import cats.effect.Sync
 import cats.syntax.flatMap._
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.TracerLog
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -32,15 +32,15 @@ object tracerlog {
       def logger[A](implicit ct: ClassTag[A]): F[Logger] =
         F.delay(LoggerFactory.getLogger(ct.runtimeClass))
 
-      override def info[A: ClassTag](value: String): KFX[F, Unit] = Kleisli { id =>
+      override def info[A: ClassTag](value: String): KFX[F, Unit] = KFX { id =>
         logger[A].flatMap(log => F.delay(log.info(s"$id >> $value")))
       }
 
-      override def error[A: ClassTag](error: Exception): KFX[F, Unit] = Kleisli { id =>
-        logger[A].flatMap(log => F.delay(log.error(s"$id >> ${error.getMessage}")))
+      override def error[A: ClassTag](value: String): KFX[F, Unit] = KFX { id =>
+        logger[A].flatMap(log => F.delay(log.error(s"$id >> $value")))
       }
 
-      override def warn[A: ClassTag](value: String): KFX[F, Unit] = Kleisli { id =>
+      override def warn[A: ClassTag](value: String): KFX[F, Unit] = KFX { id =>
         logger[A].flatMap(log => F.delay(log.warn(s"$id >> $value")))
       }
     }

--- a/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/Module.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.tracer
 
 import cats.effect.Sync
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.http.UserRoutes
 import com.github.gvolpe.tracer.interpreter.UserTracerInterpreter

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/AuthRoutes.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.tracer.http
 
 import cats.effect.Sync
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.auth.{AuthTracedHttpRoute, Http4sAuthTracerDsl}
 import io.circe.generic.auto._

--- a/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/http/UserRoutes.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.tracer.http
 
 import cats.effect.Sync
 import cats.syntax.all._
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.model.user.{User, Username}
 import com.github.gvolpe.tracer.program.{UserAlreadyExists, UserNotFound}

--- a/examples/src/main/scala/com/github/gvolpe/tracer/interpreter/UserTracerInterpreter.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/interpreter/UserTracerInterpreter.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.tracer.interpreter
 
 import cats.MonadError
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.TracerLog
 import com.github.gvolpe.tracer.algebra.UserAlgebra
 import com.github.gvolpe.tracer.model.user.{User, Username}

--- a/examples/src/main/scala/com/github/gvolpe/tracer/repository/UserTracerRepository.scala
+++ b/examples/src/main/scala/com/github/gvolpe/tracer/repository/UserTracerRepository.scala
@@ -16,10 +16,10 @@
 
 package com.github.gvolpe.tracer.repository
 
-import cats.data.Kleisli
 import cats.effect.Sync
 import cats.syntax.all._
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.TracerLog
 import com.github.gvolpe.tracer.model.user.{User, Username}
 import com.github.gvolpe.tracer.repository.algebra.UserRepository
@@ -27,14 +27,14 @@ import com.github.gvolpe.tracer.repository.algebra.UserRepository
 class UserTracerRepository[F[_]](implicit F: Sync[F], L: TracerLog[KFX[F, ?]]) extends UserRepository[KFX[F, ?]] {
   private val users = scala.collection.mutable.Map.empty[Username, User]
 
-  override def find(username: Username): KFX[F, Option[User]] = Kleisli { id =>
+  override def find(username: Username): KFX[F, Option[User]] = KFX { id =>
     for {
       _ <- L.info[UserRepository[F]](s"Find user by username: ${username.value}").run(id)
       u <- F.delay(users.get(username))
     } yield u
   }
 
-  override def persist(user: User): KFX[F, Unit] = Kleisli { id =>
+  override def persist(user: User): KFX[F, Unit] = KFX { id =>
     for {
       _ <- L.info[UserRepository[F]](s"Persisting user: ${user.username.value}").run(id)
       _ <- F.delay(users.update(user.username, user))

--- a/examples/src/test/scala/com/github/gvolpe/tracer/http/UserRoutesSpec.scala
+++ b/examples/src/test/scala/com/github/gvolpe/tracer/http/UserRoutesSpec.scala
@@ -17,7 +17,7 @@
 package com.github.gvolpe.tracer.http
 
 import cats.effect.IO
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer.model.user.{User, Username}
 import com.github.gvolpe.tracer.program.UserProgram
 import com.github.gvolpe.tracer.repository.TestUserRepository

--- a/site/src/main/tut/guide.md
+++ b/site/src/main/tut/guide.md
@@ -55,7 +55,7 @@ class UserProgram[F[_]](repo: UserRepository[F])(implicit F: MonadError[F, Throw
 And an `interpreter` that just adds the tracing log part to it, by following a `tagless final` encoding:
 
 ```tut:book:silent
-import com.github.gvolpe.tracer.Tracer.KFX
+import com.github.gvolpe.tracer.KFX._
 import com.github.gvolpe.tracer._
 
 class UserTracerInterpreter[F[_]](repo: UserRepository[KFX[F, ?]])(implicit F: MonadError[F, Throwable], L: TracerLog[KFX[F, ?]]) extends UserProgram[KFX[F, ?]](repo) {


### PR DESCRIPTION
closes #7 and introduces a convenient `KFX.apply` method inline with the type alias `KFX[F[_], A]`.

Using `Kleisli.apply` works fine sometimes but in many other occasions one is forced to specify the types as in `Kleisli[F, TraceId, A] { id => ... }` because the Scala compiler can't infer the type. Hence the introduction of `KFX.apply`.