### PR TITLE
Making creation of Tracer non-effectful

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/tracer/instances/tracer.scala
+++ b/core/src/main/scala/com/github/gvolpe/tracer/instances/tracer.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 com.github.gvolpe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.tracer
+package instances
+
+object tracer {
+  implicit def defaultTracer[F[_]]: Tracer[F] = Tracer.create[F]()
+}

--- a/core/src/test/scala/com/github/gvolpe/tracer/TracerSpec.scala
+++ b/core/src/test/scala/com/github/gvolpe/tracer/TracerSpec.scala
@@ -47,9 +47,8 @@ trait TracerFixture extends PropertyChecks {
   val customHeaderName  = "Test-Id"
   val customHeaderValue = "my-custom-value"
 
-  // yolo
-  val tracer: Tracer[IO] = Tracer.create[IO]().unsafeRunSync
-  val customTracer: Tracer[IO] = Tracer.create[IO](customHeaderName).unsafeRunSync()
+  val tracer: Tracer[IO] = Tracer.create[IO]()
+  val customTracer: Tracer[IO] = Tracer.create[IO](customHeaderName)
 
   val tracerApp: HttpApp[IO]        = tracer.middleware(TestHttpRoute.routes(tracer).orNotFound)
   val customTracerApp: HttpApp[IO]  = customTracer.middleware(TestHttpRoute.routes(customTracer).orNotFound)

--- a/examples/src/test/scala/com/github/gvolpe/tracer/http/UserRoutesSpec.scala
+++ b/examples/src/test/scala/com/github/gvolpe/tracer/http/UserRoutesSpec.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.tracer.http
 
 import cats.effect.IO
 import com.github.gvolpe.tracer.Trace._
-import com.github.gvolpe.tracer.Tracer
+import com.github.gvolpe.tracer.instances.tracer._
 import com.github.gvolpe.tracer.model.user.{User, Username}
 import com.github.gvolpe.tracer.program.UserProgram
 import com.github.gvolpe.tracer.repository.TestUserRepository
@@ -28,8 +28,6 @@ import org.http4s.{Request, Status, Uri}
 import org.scalatest.prop.TableFor3
 
 class UserRoutesSpec extends HttpRoutesSpec {
-
-  implicit val tracer: Tracer[IO] = Tracer.create[IO]().unsafeRunSync // yolo
 
   private val repo    = new TestUserRepository[Trace[IO, ?]]
   private val program = new UserProgram[Trace[IO, ?]](repo)


### PR DESCRIPTION
It still needs to keep the "header name" as internal state so we need to create an instance.